### PR TITLE
Replace sklearn with scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ vtk
 click
 pint
 pyarrow
-sklearn
+scikit-learn
 pyyaml
 
 ladybug-core>=0.38.0


### PR DESCRIPTION
scikit-learn is the actual package name (see details [here](https://pypi.org/project/sklearn/))

Fixes https://github.com/SimScaleGmbH/external-building-aerodynamics/issues/30